### PR TITLE
feat: confirm before deleting request history

### DIFF
--- a/app/src/main/java/com/halovoid/lncrawler/ui/screens/request/ConfirmDeleteDialog.kt
+++ b/app/src/main/java/com/halovoid/lncrawler/ui/screens/request/ConfirmDeleteDialog.kt
@@ -1,0 +1,46 @@
+package com.halovoid.lncrawler.ui.screens.request
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.halovoid.lncrawler.ui.theme.DarkSurface
+import com.halovoid.lncrawler.ui.theme.PrimaryText
+import com.halovoid.lncrawler.ui.theme.SecondaryText
+
+/**
+ * Shared confirmation dialog for destructive delete actions.
+ *
+ * @param title Short title that identifies the action.
+ * @param message What will be removed and whether the action is irreversible.
+ * @param onConfirm Callback invoked only after explicit user confirmation.
+ * @param onDismiss Callback invoked when the dialog is dismissed.
+ */
+@Composable
+fun ConfirmDeleteDialog(
+    title: String,
+    message: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title, color = PrimaryText) },
+        text = { Text(message, color = SecondaryText) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text("Delete", color = Color.Red.copy(alpha = 0.85f))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel", color = PrimaryText)
+            }
+        },
+        containerColor = DarkSurface,
+        shape = RoundedCornerShape(12.dp)
+    )
+}

--- a/app/src/main/java/com/halovoid/lncrawler/ui/screens/request/RequestDetailScreen.kt
+++ b/app/src/main/java/com/halovoid/lncrawler/ui/screens/request/RequestDetailScreen.kt
@@ -49,6 +49,7 @@ fun RequestDetailScreen(
     val record by viewModel.getRecord(recordId).collectAsState(initial = null)
     val novel by viewModel.novel.collectAsState()
     val progressMap by viewModel.exportProgressMap.collectAsState()
+    var showDeleteConfirmation by remember { mutableStateOf(false) }
 
     val exportLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.CreateDocument("application/epub+zip")
@@ -208,10 +209,7 @@ fun RequestDetailScreen(
                                     verticalAlignment = Alignment.CenterVertically
                                 ) {
                                     OutlinedIconButton(
-                                        onClick = {
-                                            viewModel.deleteHistoryRecord(currentRecord.id, currentRecord.novelUrl)
-                                            onBackClick()
-                                        },
+                                        onClick = { showDeleteConfirmation = true },
                                         border = BorderStroke(1.dp, BorderColor),
                                         colors = IconButtonDefaults.outlinedIconButtonColors(
                                             containerColor = DarkSurface,
@@ -318,6 +316,20 @@ fun RequestDetailScreen(
                 }
                 
                 Spacer(modifier = Modifier.height(24.dp))
+            }
+
+            if (showDeleteConfirmation) {
+                val displayName = currentRecord.novelTitle.ifBlank { currentRecord.novelUrl }
+                ConfirmDeleteDialog(
+                    title = "Delete request?",
+                    message = "This will permanently remove \"$displayName\" from your request history. This action cannot be undone.",
+                    onConfirm = {
+                        showDeleteConfirmation = false
+                        viewModel.deleteHistoryRecord(currentRecord.id, currentRecord.novelUrl)
+                        onBackClick()
+                    },
+                    onDismiss = { showDeleteConfirmation = false }
+                )
             }
         }
     }

--- a/app/src/main/java/com/halovoid/lncrawler/ui/screens/request/RequestScreen.kt
+++ b/app/src/main/java/com/halovoid/lncrawler/ui/screens/request/RequestScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.halovoid.lncrawler.domain.models.ExportRecord
 import com.halovoid.lncrawler.domain.models.ExportStatus
 import com.halovoid.lncrawler.ui.theme.*
 import java.text.SimpleDateFormat
@@ -49,6 +50,7 @@ fun RequestScreen(
     val progressMap by viewModel.exportProgressMap.collectAsState()
     val context = LocalContext.current
     val isFetching = !activeFetches.isEmpty()
+    var pendingDelete by remember { mutableStateOf<ExportRecord?>(null) }
 
     Scaffold(
         containerColor = DarkBackground,
@@ -243,11 +245,22 @@ fun RequestScreen(
                             Toast.makeText(context, "Refresh started", Toast.LENGTH_SHORT).show()
                         }
                     },
-                    onRemove = { 
-                        viewModel.deleteHistoryRecord(record.id, record.novelUrl)
-                    }
+                    onRemove = { pendingDelete = record }
                 )
             }
+        }
+
+        pendingDelete?.let { record ->
+            val displayName = record.novelTitle.ifBlank { record.novelUrl }
+            ConfirmDeleteDialog(
+                title = "Delete request?",
+                message = "This will permanently remove \"$displayName\" from your request history. This action cannot be undone.",
+                onConfirm = {
+                    viewModel.deleteHistoryRecord(record.id, record.novelUrl)
+                    pendingDelete = null
+                },
+                onDismiss = { pendingDelete = null }
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds an explicit confirmation step before destructive delete actions in the request history.

## Changes

- Adds a shared `ConfirmDeleteDialog` composable with clear Delete and Cancel actions.
- Request history: removing a record now asks for confirmation before deleting.
- Request detail: deleting the current request now asks for confirmation before deleting and navigating back.

## Testing

- `./gradlew :app:assembleDebug` passes.
- `./gradlew :app:testDebugUnitTest` passes.

Closes #15